### PR TITLE
Add width option to prevent wrapping

### DIFF
--- a/yaml.py
+++ b/yaml.py
@@ -57,7 +57,7 @@ class Yaml():
 
     def write_file(self, yaml_file):
         yaml_file.seek(0)
-        yaml_file.write( pyyaml.dump(self.yaml_to_write, default_flow_style = False, allow_unicode = True, encoding = None) )
+        yaml_file.write( pyyaml.dump(self.yaml_to_write, default_flow_style = False, allow_unicode = True, encoding = None, width = 1000) )
         yaml_file.truncate()
 
     def value_count(self, key):


### PR DESCRIPTION
Was running into issues where long strings were getting wrapped by the dumper and causing the document highlighting to go AWOL.

http://stackoverflow.com/questions/18514205/how-to-prevent-yaml-to-dump-long-line-without-new-line
